### PR TITLE
feat: Implement Creator Cards with Profile Details

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -6,7 +6,7 @@ import Footer from './componentes/Footer';
 import Blogs from './pages/Blogs';
 import About from './pages/About';
 import Contact from './pages/Contact';
-import Creators from './pages/Creator';
+import Creators from './pages/Creators';
 import Login from './pages/Login';
 import SignUp from './pages/SignUp';
 import Dashboard from './pages/Dashboard';
@@ -33,7 +33,7 @@ function App() {
         <Route path="/dashboard" element={<Dashboard/>}/>
        </Routes>
        <Toaster />
-       {/* {!hidePages && <Footer/>} */}
+       {!hidePages && <Footer/>}
       </div>
     </>
   )

--- a/frontend/src/componentes/Home.jsx
+++ b/frontend/src/componentes/Home.jsx
@@ -3,8 +3,6 @@ import Hero from '../home/Hero.jsx';
 import Trending from '../home/Trending.jsx';
 import Devotaional from '../home/Devotional.jsx';
 import PopularCreators from '../home/PopularCreators.jsx';
-import Footer from './Footer.jsx';
-
 const Home = () => {
   
   return (
@@ -13,7 +11,6 @@ const Home = () => {
       <Trending />
       <Devotaional />
       <PopularCreators />
-      <Footer/>
     </div>
   )
 }

--- a/frontend/src/componentes/Navebar.jsx
+++ b/frontend/src/componentes/Navebar.jsx
@@ -9,7 +9,7 @@ const Navebar = () => {
   const menuLinks = [
     { to: "/", label: "Home" },
     { to: "/blogs", label: "Blogs" },
-    { to: "/creators", label: "Creatores" },
+    { to: "/creators", label: "Creators" },
     { to: "/about", label: "About" },
     { to: "/contact", label: "Contact" },
   ];

--- a/frontend/src/pages/Creator.jsx
+++ b/frontend/src/pages/Creator.jsx
@@ -1,9 +1,0 @@
-import React from 'react'
-
-const Creator = () => {
-  return (
-    <div>Creator</div>
-  )
-}
-
-export default Creator

--- a/frontend/src/pages/Creators.jsx
+++ b/frontend/src/pages/Creators.jsx
@@ -1,0 +1,61 @@
+import axios from 'axios';
+import React, { useEffect, useState } from 'react';
+
+const Creators = () => {
+  const [creator, setCreator] = useState([]);
+
+  useEffect(() => {
+    const fetchCreatorsDetails = async () => {
+      try {
+        const { data } = await axios.get("http://localhost:3000/user/admins", {
+          withCredentials: true,
+        });
+        console.log("creators data: ", data);
+        setCreator(data);
+      } catch (error) {
+        console.error("Error fetching creators data:", error);
+      }
+    };
+    fetchCreatorsDetails();
+  }, []);
+
+  const renderCreatorCard = (item) => (
+    <div key={item._id} className='flex flex-col items-center rounded-lg shadow-lg overflow-hidden group'>
+      <div className='w-72 h-52 md:w-52 md:h-28 relative flex justify-center'>
+        <img
+          className='w-full h-full bg-black object-cover'
+          src={item?.profileImage?.url || "/default-image.jpg"}
+          alt="profile"
+        />
+        <div className='absolute -bottom-7 w-14 h-14 rounded-full bg-yellow-400 overflow-hidden border-2 group-hover:rounded-md group-hover:-bottom-9 duration-500 ease-in-out'>
+          <img
+            className='bg-red-300 w-full h-full'
+            src={item?.profileImage?.url || "/default-avatar.jpg"}
+            alt="avatar"
+          />
+        </div>
+      </div>
+
+      <div className='pt-10 text-center'>
+        <h1 className='font-bold capitalize'>{item?.name || "Anonymous"}</h1>
+        <p className='font-semibold text-slate-600'>{item?.email || "No Email Available"}</p>
+        <div className='flex space-x-12 py-2'>
+          <p className='text-gray-500 text-sm'>{item?.mobileNumber || "No Number"}</p>
+          <p className='text-gray-500 text-sm'>{item?.education || "No Education Info"}</p>
+        </div>
+      </div>
+    </div>
+  );
+
+  return (
+    <div className='w-full flex justify-center flex-wrap py-4 gap-5'>
+      {creator.length > 0 ? (
+        creator.map(renderCreatorCard)
+      ) : (
+        <p>No creators found</p>
+      )}
+    </div>
+  );
+};
+
+export default Creators;


### PR DESCRIPTION
### Description:
This pull request introduces a new feature for rendering creator profile cards. It includes:
- Axios API call to fetch creator data from the backend (`/user/admins` route).
- Display of creators' profile images, names, emails, phone numbers, and education.
- Added smooth hover transitions on profile images and avatars for a better UI experience.
- Fallback support for missing data with default images and placeholder text.

### Changes:
- `Creators.js`: Created component to handle API fetching and card rendering.
- Applied Tailwind CSS classes for responsive and visually appealing layout.
