### PR TITLE
feat: implement optional 'Remember Me' functionality for login

### DIFF
--- a/backend/controller/blog_analysis.js
+++ b/backend/controller/blog_analysis.js
@@ -41,7 +41,6 @@ export const getAnalysisData = async (req, res) => {
       },
       { $sort: { _id: 1 } },
     ]);
-    console.log(data);
     const totalSummary = data.reduce(
       (acc, data) => {
         acc.totalBlogs += data.totalBlogs;

--- a/backend/controller/user_controller.js
+++ b/backend/controller/user_controller.js
@@ -22,7 +22,7 @@ export const signUpUser = async (req, res) => {
       });
     }
 
-    const { name, email, password, mobileNumber, education, role, createdAt } =
+    const { name, email, password, mobileNumber, education, role } =
       req.body;
     if (
       !name ||
@@ -88,7 +88,7 @@ export const signUpUser = async (req, res) => {
 
 // Login User
 export const logInUser = async (req, res) => {
-  const { email, password, role } = req.body;
+  const { email, password, role, rememberMe } = req.body;
   try {
     if (!email || !password || !role) {
       return res.status(400).json({ message: "Please fill required fields" });
@@ -104,7 +104,7 @@ export const logInUser = async (req, res) => {
     if (user.role !== role) {
       return res.status(400).json({ message: `Invalid role ${role}` });
     }
-    const token = await createTokenAndSaveCookie(user._id, res);
+    const token = await createTokenAndSaveCookie(user._id, res, rememberMe);
     // console.log(token);
 
     res.status(200).json({

--- a/backend/jwt/AuthenticateToken.js
+++ b/backend/jwt/AuthenticateToken.js
@@ -1,11 +1,11 @@
 import jwt from 'jsonwebtoken';
 import userModel from '../models/user_model.js';
 
-const createTokenAndSaveCookies = async (userId, res) => {
+const createTokenAndSaveCookies = async (userId, res, rememberMe = false) => {
     // console.log(process.env.JWT_SECRET);
     
     const token = jwt.sign({ userId }, process.env.JWT_SECRET,{
-        expiresIn: "7d"
+        expiresIn: rememberMe ? "7d" : "1h",
     });
     res.cookie("jwttoken", token , {
         httpOnly: false, //protect from xss attck 

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -11,6 +11,7 @@ const Login = () => {
   const [password, setPassword] = useState("");
   const [loading, setLoading] = useState(false);
   const [showPassword, setShowPassword] = useState(false);
+  const [rememberMe, setRememberMe] = useState(false);
 
   const handleLoginSubmit = async (e) => {
     e.preventDefault();
@@ -22,7 +23,7 @@ const Login = () => {
     try {
       await axios.post(
         `${import.meta.env.VITE_APP_BACKEND_URL}/user/login`,
-        { role, email, password },
+        { role, email, password, rememberMe },
         {
           withCredentials: true,
           headers: {
@@ -217,6 +218,7 @@ const Login = () => {
                     className="mt-1 mr-2 h-5 w-5 appearance-none rounded border border-gray-300 bg-contain bg-no-repeat align-top text-black shadow checked:bg-indigo-500 focus:border-indigo-500 focus:shadow"
                     type="checkbox"
                     id="remember-me"
+                     onChange={() => setRememberMe(!rememberMe)}
                   />
                   <label className="inline-block" htmlFor="remember-me">
                     {" "}


### PR DESCRIPTION
# feat: add 'Remember Me' support in login flow only

- Remember Me checkbox included in login form
- Token expiry set to 7 days if Remember Me is checked, else 1 hour
- Signup flow remains unaffected
- createTokenAndSaveCookies handles optional rememberMe param
